### PR TITLE
Api extension

### DIFF
--- a/src/main/java/org/avaje/datasource/DataSourceAlert.java
+++ b/src/main/java/org/avaje/datasource/DataSourceAlert.java
@@ -1,5 +1,9 @@
 package org.avaje.datasource;
 
+import java.sql.SQLException;
+
+import javax.sql.DataSource;
+
 /**
  * Listener for notifications about the DataSource such as when the DataSource
  * goes down, up or gets close to it's maximum size.
@@ -13,15 +17,15 @@ public interface DataSourceAlert {
   /**
    * Send an alert to say the dataSource is back up.
    */
-  void dataSourceUp(String dataSourceName);
+  void dataSourceUp(DataSource dataSource);
 
   /**
    * Send an alert to say the dataSource is down.
    */
-  void dataSourceDown(String dataSourceName);
+  void dataSourceDown(DataSource dataSource, SQLException reason);
 
   /**
    * Send an alert to say the dataSource is getting close to its max size.
    */
-  void dataSourceWarning(String subject, String msg);
+  void dataSourceWarning(DataSource dataSource, String msg);
 }

--- a/src/main/java/org/avaje/datasource/DataSourcePool.java
+++ b/src/main/java/org/avaje/datasource/DataSourcePool.java
@@ -1,5 +1,7 @@
 package org.avaje.datasource;
 
+import java.sql.SQLException;
+
 import javax.sql.DataSource;
 
 /**
@@ -41,5 +43,35 @@ public interface DataSourcePool extends DataSource {
    * </p>
    */
   PoolStatistics getStatistics(boolean reset);
+
+  /**
+   * Returns false when the dataSource is down.
+   */
+  boolean isDataSourceUp();
+
+  /**
+   * Returns the reason, why the dataSource is down.
+   */
+  SQLException getDataSourceDownReason();
+
+  /**
+   * Set a new maximum size. The pool should respect this new maximum
+   * immediately and not require a restart. You may want to increase the
+   * maxConnections if the pool gets large and hits the warning level.
+   */
+  void setMaxSize(int max);
+
+  /**
+   * Set a new maximum size. The pool should respect this new maximum immediately
+   * and not require a restart. You may want to increase the maxConnections if the
+   * pool gets large and hits the warning and or alert levels.
+   */
+  void setWarningSize(int warningSize);
+
+  /**
+    * Return the warning size. When the pool hits this size it can send a
+    * notify message to an administrator.
+    */
+   public int getWarningSize();
 
 }


### PR DESCRIPTION

## Adds methods to DataSourcePool-API:
- boolean isDataSourceUp();
- SQLException getDataSourceDownReason();
- void setMaxSize(int max);
- void setWarningSize(int warningSize);
- public int getWarningSize();

## Changes DataSourceAlert-API:
DataSource is passed instead of DataSource Name

## Changes in DataSourceConfig
- failOnStart option
- initSql (required for 'SET NAMES utf8' in MariaDb/MySQL)
